### PR TITLE
feat(nav) add Nav component, create Main layout #12

### DIFF
--- a/web/src/component/Nav.tsx
+++ b/web/src/component/Nav.tsx
@@ -1,0 +1,80 @@
+import {
+  Button,
+  Flex,
+  Space,
+  Text,
+  useMantineColorScheme,
+} from "@mantine/core";
+import { useMediaQuery } from "@mantine/hooks";
+import NextLink from "next/link";
+import { useRouter } from "next/router";
+
+interface NavigationLink {
+  label: string;
+  href: string;
+}
+
+const navigationLinks: NavigationLink[] = [
+  {
+    label: "HOME",
+    href: "/home",
+  },
+  {
+    label: "ABOUT",
+    href: "/about",
+  },
+];
+
+export default function Nav() {
+  const { colorScheme } = useMantineColorScheme();
+  const isMobile = useMediaQuery("(max-width: 768px)");
+  const router = useRouter();
+  const links = navigationLinks.map((link) => {
+    if (router.pathname === link.href) return;
+    return (
+      <Button
+        component={NextLink}
+        href={link.href}
+        key={link.label}
+        variant="subtle"
+        color="white"
+      >
+        {link.label}
+      </Button>
+    );
+  });
+  return (
+    <Flex
+      component="nav"
+      direction="row"
+      align="center"
+      justify="flex-start"
+      w={"100vw"}
+      h={64}
+      p={16}
+      style={{
+        backgroundColor:
+          colorScheme === "dark"
+            ? "var(--mantine-color-default-hover)"
+            : "#006633",
+        borderBottom: `2px solid ${
+          colorScheme === "dark"
+            ? "var(--mantine-color-default-border)"
+            : "#003300"
+        }`,
+      }}
+    >
+      <Text
+        size={isMobile ? "md" : "lg"}
+        fw={"bold"}
+        style={{ color: "white" }}
+      >
+        GMU_ACM_Algorithms_Visualizer
+      </Text>
+      <Space />
+      <Flex align="center" justify="flex-end" ml={"auto"}>
+        {links}
+      </Flex>
+    </Flex>
+  );
+}

--- a/web/src/layouts/Main.tsx
+++ b/web/src/layouts/Main.tsx
@@ -1,0 +1,14 @@
+import Nav from "@/component/Nav";
+
+export default function MainLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Nav />
+      {children}
+    </>
+  );
+}

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -1,23 +1,35 @@
-import '@mantine/core/styles.css';
-import '@/styles/globals.css';
-import { createTheme, MantineProvider } from '@mantine/core';
-import type { AppProps } from 'next/app';
-import Head from 'next/head';
+import "@mantine/core/styles.css";
+import "@/styles/globals.css";
+import { createTheme, MantineProvider } from "@mantine/core";
+import type { AppProps } from "next/app";
+import type { ReactElement, ReactNode } from "react";
+import Head from "next/head";
+import { NextPage } from "next/types";
 
 const theme = createTheme({
   /** Put your mantine theme override here */
 });
 
-export default function App({ Component, pageProps }: AppProps) {
+export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+};
+
+export default function App({ Component, pageProps }: AppPropsWithLayout) {
+  const getLayout = Component.getLayout ?? ((page) => page);
+
   return (
     <>
-      <MantineProvider theme={theme}>
+      <MantineProvider theme={theme} forceColorScheme="light">
         {/* display the algorithm visualizer */}
         <Head>
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <title>Algorithm Visualizer</title>
         </Head>
-        <Component {...pageProps} />
+        {getLayout(<Component {...pageProps} />)}
       </MantineProvider>
     </>
   );

--- a/web/src/pages/about/index.tsx
+++ b/web/src/pages/about/index.tsx
@@ -1,6 +1,19 @@
-import React from 'react';
-interface AboutProps {}
-const About: React.FC<AboutProps> = () => {
-  return <div className="">About</div>;
+import Head from "next/head";
+import MainLayout from "@/layouts/Main";
+import { ReactElement } from "react";
+import { Box, Text, Title } from "@mantine/core";
+
+function Page<NextPageWithLayout>() {
+  return (
+    <>
+      {/* Main Content */}
+      <Title order={1}>About</Title>
+    </>
+  );
+}
+
+Page.getLayout = function getLayout(page: ReactElement) {
+  return <MainLayout>{page}</MainLayout>;
 };
-export default About;
+
+export default Page;

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -1,6 +1,19 @@
-import React from 'react';
-interface HomeProps {}
-const Home: React.FC<HomeProps> = () => {
-  return <div className="">Home</div>;
+import Head from "next/head";
+import MainLayout from "@/layouts/Main";
+import { ReactElement } from "react";
+import { Box, Text, Title } from "@mantine/core";
+
+function Page<NextPageWithLayout>() {
+  return (
+    <>
+      {/* Main Content */}
+      <Title order={1}>Welcome to the Algorithm Visualizer</Title>
+    </>
+  );
+}
+
+Page.getLayout = function getLayout(page: ReactElement) {
+  return <MainLayout>{page}</MainLayout>;
 };
-export default Home;
+
+export default Page;


### PR DESCRIPTION
Created the Nav component as requested in issue #12. In addition, I've created a main layout that will be used across the website.

As of now, I made it so that a navigation link will disappear if it's already on the route that it is associated with. Let me know if you want that behavior to change.

![Algorithm Visualizer](https://github.com/StoicNeutron/GMU_ACM/assets/35532005/39e1ba65-d39a-4613-88c4-429ceed4c151)
